### PR TITLE
fix: 친구 초대, 회원 조회(친구 검색), 버디 리스트 조회 API 수정

### DIFF
--- a/src/main/java/com/linkbuddy/domain/buddy/BuddyController.java
+++ b/src/main/java/com/linkbuddy/domain/buddy/BuddyController.java
@@ -23,13 +23,11 @@ public class BuddyController {
 
     /**
      * 회원 버디 리스트 조회
-     * @param userId
      * @return
      */
     @GetMapping
-    public ResponseEntity getBuddyList(@RequestParam(value = "userId") Long userId) throws Exception {
-        log.info("userId = {}", userId);
-        List<BuddyDTO.BuddyResponse> buddyList = buddyService.findAll(userId);
+    public ResponseEntity getBuddyList() throws Exception {
+        List<BuddyDTO.BuddyResponse> buddyList = buddyService.findAll();
         return ResponseEntity.ok(ResponseMessage.builder()
                 .status(StatusEnum.OK)
                 .data(buddyList)

--- a/src/main/java/com/linkbuddy/domain/buddy/BuddyService.java
+++ b/src/main/java/com/linkbuddy/domain/buddy/BuddyService.java
@@ -3,6 +3,7 @@ package com.linkbuddy.domain.buddy;
 import com.linkbuddy.domain.buddy.dto.BuddyDTO;
 import com.linkbuddy.domain.buddy.repository.BuddyRepository;
 import com.linkbuddy.domain.buddyUser.repository.BuddyUserRepository;
+import com.linkbuddy.global.config.jwt.SecurityUtil;
 import com.linkbuddy.global.entity.Buddy;
 import com.linkbuddy.global.entity.BuddyUser;
 import jakarta.transaction.Transactional;
@@ -24,15 +25,18 @@ public class BuddyService {
     @Autowired
     private BuddyUserRepository buddyUserRepository;
 
+    @Autowired
+    private SecurityUtil securityUtil;
+
     /**
-     * 회원 버디 리스트 조회 (By userId)
-     * @param userId
+     * 회원 버디 리스트 조회
      * @return
      * @throws Exception
      */
-    public List<BuddyDTO.BuddyResponse> findAll(Long userId) throws Exception {
+    public List<BuddyDTO.BuddyResponse> findAll() throws Exception {
         try {
-            List<BuddyDTO.BuddyResponse> buddyList = buddyRepository.findBuddyByUserId(userId);
+            Long currentUserId = securityUtil.getCurrentUserId();
+            List<BuddyDTO.BuddyResponse> buddyList = buddyRepository.findBuddyByUserId(currentUserId);
             return buddyList;
 
         } catch (Exception e) {
@@ -77,6 +81,7 @@ public class BuddyService {
             BuddyUser newBuddyUser = BuddyUser.builder()
                     .userId(buddy.getUserId())
                     .buddyId(savedBuddy.getId())
+                    .senderId(null)
                     .alertTf(true)
                     .pinTf(false)
                     .acceptTf(true)

--- a/src/main/java/com/linkbuddy/domain/buddyUser/BuddyUserService.java
+++ b/src/main/java/com/linkbuddy/domain/buddyUser/BuddyUserService.java
@@ -64,14 +64,16 @@ public class BuddyUserService {
      */
     public BuddyUser createBuddyUser(BuddyDTO buddy) throws Exception {
         try {
-            User user = userRepository.customFindByEmail(buddy.getEmail());
+            Long currentUserId = securityUtil.getCurrentUserId();
+            User invitedUser = userRepository.customFindByEmail(buddy.getEmail());
 
             // 버디 회원 조회
-            BuddyUser buddyUser = buddyUserRepository.findBuddyUserByBuddyIdAndUserId(buddy.getBuddyId(), user.getId());
+            BuddyUser buddyUser = buddyUserRepository.findBuddyUserByBuddyIdAndUserId(buddy.getBuddyId(), invitedUser.getId());
             if (buddyUser == null) {
                 BuddyUser newBuddyUser = BuddyUser.builder()
-                        .userId(user.getId())
+                        .userId(invitedUser.getId())
                         .buddyId(buddy.getBuddyId())
+                        .senderId(currentUserId)
                         .alertTf(true)  //알림여부
                         .pinTf(false)   //고정여부
                         .acceptTf(false)    //수락여부
@@ -125,6 +127,7 @@ public class BuddyUserService {
             BuddyUser newBuddyUser = BuddyUser.builder()
                     .userId(userId)
                     .buddyId(buddyUser.getBuddyId())
+                    .senderId(buddyUser.getSenderId())
                     .alertTf(buddyDTO.getAlertTf() != null ? buddyDTO.getAlertTf() : buddyUser.getAlertTf())
                     .pinTf(buddyDTO.getPinTf() != null ? buddyDTO.getPinTf() : buddyUser.getPinTf())
                     .acceptTf(buddyDTO.getAcceptTf() != null ? buddyDTO.getAcceptTf() : buddyUser.getAcceptTf())

--- a/src/main/java/com/linkbuddy/domain/user/UserController.java
+++ b/src/main/java/com/linkbuddy/domain/user/UserController.java
@@ -62,12 +62,20 @@ public class UserController {
     log.info("user data = {}", user);
 
     if (user == null) {
-      return ResponseEntity.notFound().build();
+      return ResponseEntity.ok(ResponseMessage.builder()
+              .status(StatusEnum.NOT_FOUND)
+              .build());
+    } else {
+      HashMap<String, Object> userData = new HashMap<>();
+      userData.put("id", user.getId());
+      userData.put("name", user.getName());
+      userData.put("email", user.getEmail());
+
+      return ResponseEntity.ok(ResponseMessage.builder()
+              .status(StatusEnum.OK)
+              .data(userData)
+              .build());
     }
-    return ResponseEntity.ok(ResponseMessage.builder()
-            .status(StatusEnum.OK)
-            .data(user)
-            .build());
   }
 
   @PostMapping("/signIn")

--- a/src/main/java/com/linkbuddy/domain/user/UserService.java
+++ b/src/main/java/com/linkbuddy/domain/user/UserService.java
@@ -53,6 +53,7 @@ public class UserService {
     try {
       log.info("email = {}", email);
       return userRepository.customFindByEmail(email);
+
     } catch (Exception e) {
       throw new Exception();
     }

--- a/src/main/java/com/linkbuddy/global/entity/BuddyUser.java
+++ b/src/main/java/com/linkbuddy/global/entity/BuddyUser.java
@@ -32,6 +32,10 @@ public class BuddyUser {
     @Comment(value = "회원ID")
     private Long userId;
 
+    @Column(name = "sender_id", nullable = true)
+    @Comment(value = "발송자ID")
+    private Long senderId;
+
     @Column(name = "alert_tf", nullable = false)
     @Comment(value = "알림여부")
     private Boolean alertTf = true;
@@ -70,9 +74,10 @@ public class BuddyUser {
 
 
     @Builder
-    public BuddyUser(Long userId, Long buddyId, Boolean alertTf, Boolean pinTf, Boolean acceptTf, Timestamp acceptDt) {
+    public BuddyUser(Long userId, Long buddyId, Long senderId, Boolean alertTf, Boolean pinTf, Boolean acceptTf, Timestamp acceptDt) {
         this.userId = userId;
         this.buddyId = buddyId;
+        this.senderId = senderId;
         this.alertTf = alertTf;
         this.pinTf = pinTf;
         this.acceptTf = acceptTf;


### PR DESCRIPTION
 ## PR타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링, 코드 포맷팅
- [ ] CI/CD, 환경변수
- [ ] 문서 작업

 ## 내용
버디 리스트 조회 API 수정
1. 고정 userId 및 parameter userId 설정 삭제 

친구 초대 API 수정
1.  초대한 userId buddyUser 테이블에 컬럼 추가 (sender_id)
2. 친구 초대시 buddyUser 테이블에 sender_id 데이터 추가 

친구 검색
1. 친구 검색 실패시 로직 추가 및 return data 수정

resolves