### PR TITLE
fix: 버디 초대 목록 조회 & 버디 생성 API 수정

### DIFF
--- a/src/main/java/com/linkbuddy/domain/buddy/BuddyController.java
+++ b/src/main/java/com/linkbuddy/domain/buddy/BuddyController.java
@@ -61,8 +61,13 @@ public class BuddyController {
      * @throws Exception
      */
     @PostMapping
-    public ResponseEntity createBuddy(BuddyDTO buddy) throws Exception {
+    public ResponseEntity createBuddy(@RequestBody BuddyDTO buddy) throws Exception {
         BuddyUser savedBuddyUser = buddyService.create(buddy);
+        if (savedBuddyUser == null) {
+            return ResponseEntity.ok(ResponseMessage.builder()
+                    .status(StatusEnum.CONFLICT)
+                    .build());
+        }
         return ResponseEntity.ok(ResponseMessage.builder()
                 .status(StatusEnum.OK)
                 .data(savedBuddyUser)

--- a/src/main/java/com/linkbuddy/domain/buddy/dto/BuddyDTO.java
+++ b/src/main/java/com/linkbuddy/domain/buddy/dto/BuddyDTO.java
@@ -25,6 +25,7 @@ public class BuddyDTO {
     private String email;
     private Long userId;
     private Long buddyId;
+    private Long senderId;
     private Boolean alertTf;
     private Boolean pinTf;
     private Boolean acceptTf;
@@ -57,15 +58,21 @@ public class BuddyDTO {
         private Long id;
         private String name;
         private Long buddyId;
+        private Long senderId;
+        private String senderName;
+        private String senderEmail;
         private Boolean acceptTf;
         private Timestamp acceptDt;
         private Timestamp createdAt;
 
         @Builder
         @QueryProjection
-        public BuddyInvitationResponse(Long id, Long buddyId, String name, Boolean acceptTf, Timestamp acceptDt, Timestamp createdAt) {
+        public BuddyInvitationResponse(Long id, Long buddyId, Long senderId, String senderName, String senderEmail, String name, Boolean acceptTf, Timestamp acceptDt, Timestamp createdAt) {
             this.id = id;
             this.buddyId = buddyId;
+            this.senderId = senderId;
+            this.senderName = senderName;
+            this.senderEmail = senderEmail;
             this.name = name;
             this.acceptTf = acceptTf;
             this.acceptDt = acceptDt;

--- a/src/main/java/com/linkbuddy/domain/buddy/repository/BuddyRepository.java
+++ b/src/main/java/com/linkbuddy/domain/buddy/repository/BuddyRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 //@Transactional
 public interface BuddyRepository extends JpaRepository<Buddy, Long>, BuddyCustomRepository {
 
+  Optional<Buddy> findByNameAndCreatorId(String name, Long currentUserId);
 }

--- a/src/main/java/com/linkbuddy/domain/buddyUser/repository/BuddyUserCustomRepositoryImpl.java
+++ b/src/main/java/com/linkbuddy/domain/buddyUser/repository/BuddyUserCustomRepositoryImpl.java
@@ -72,12 +72,14 @@ public class BuddyUserCustomRepositoryImpl implements BuddyUserCustomRepository 
 
   @Override
   public List<BuddyDTO.BuddyInvitationResponse> findBuddyUserInvitationsByUserId(Long userId) {
-    List<BuddyDTO.BuddyInvitationResponse> buddyInvitationList = query.select(new QBuddyDTO_BuddyInvitationResponse(buddyUser.id, buddyUser.buddyId, buddy.name, buddyUser.acceptTf, buddyUser.acceptDt, buddyUser.created_at))
+    List<BuddyDTO.BuddyInvitationResponse> buddyInvitationList = query.select(new QBuddyDTO_BuddyInvitationResponse(buddyUser.id, buddyUser.buddyId, buddyUser.senderId, user.name, user.email, buddy.name, buddyUser.acceptTf, buddyUser.acceptDt, buddyUser.createdAt))
             .from(buddyUser)
             .innerJoin(buddyUser.buddy, buddy)
             .on(buddyUser.buddyId.eq(buddy.id))
-            .where(buddyUser.userId.eq(userId))
-            .orderBy(buddyUser.created_at.desc())
+            .innerJoin(user)
+            .on(buddyUser.senderId.eq(user.id))
+            .where(buddyUser.userId.eq(userId).and(buddy.creatorId.eq(buddyUser.userId).not()))
+            .orderBy(buddyUser.createdAt.desc())
             .fetch();
     return buddyInvitationList;
   }

--- a/src/main/java/com/linkbuddy/global/entity/Buddy.java
+++ b/src/main/java/com/linkbuddy/global/entity/Buddy.java
@@ -27,24 +27,24 @@ public class Buddy {
     @Comment(value = "버디명")
     private String name;
 
-    @Column(nullable = false)
+    @Column(name = "creator_id", nullable = false)
     @Comment(value = "생성자ID")
-    private Long creator_id;
+    private Long creatorId;
 
     @CreationTimestamp  //Insert 쿼리 발생시 현재 시간 값 적용
     @Column(name = "created_at")
     @Comment(value = "생성일시")
-    private Timestamp created_at;
+    private Timestamp createdAt;
 
     @UpdateTimestamp    //Update 쿼리 발생시 현재 시간 값 적용
     @Column(name = "updated_at")
     @Comment(value = "수정일시")
-    private Timestamp updated_at;
+    private Timestamp updatedAt;
 
     @Builder
-    public Buddy(String name, Long creator_id) {
+    public Buddy(String name, Long creatorId) {
         this.name = name;
-        this.creator_id = creator_id;
+        this.creatorId = creatorId;
     }
 
     public void update(String name) {

--- a/src/main/java/com/linkbuddy/global/entity/BuddyUser.java
+++ b/src/main/java/com/linkbuddy/global/entity/BuddyUser.java
@@ -55,12 +55,12 @@ public class BuddyUser {
     @CreationTimestamp  //Insert 쿼리 발생시 현재 시간 값 적용
     @Column(name = "created_at")
     @Comment(value = "생성일시")
-    private Timestamp created_at;
+    private Timestamp createdAt;
 
     @UpdateTimestamp    //Update 쿼리 발생시 현재 시간 값 적용
     @Column(name = "updated_at")
     @Comment(value = "수정일시")
-    private Timestamp updated_at;
+    private Timestamp updatedAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "buddy_id", referencedColumnName = "id", insertable = false, updatable = false)


### PR DESCRIPTION
 ## PR타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링, 코드 포맷팅
- [ ] CI/CD, 환경변수
- [ ] 문서 작업

 ## 내용
1. 버디 초대 목록 조회 API 수정
-  초대자명, 초대자 이메일 데이터 추가 조회
- 버디 방장인 경우 초대 목록에서 해당 버디 제외
2. 버디 생성 API 수정
- userId 조회 공통 함수 사용
- 동일한 유저 동일한 버디 이름 중복 생성 불가 로직 추가 => 논의결과 중복허용으로 수정 필요(추후 작업)

resolves