### PR TITLE
feat: 소셜로그인 연결 중

### DIFF
--- a/src/main/java/com/linkbuddy/domain/user/UserController.java
+++ b/src/main/java/com/linkbuddy/domain/user/UserController.java
@@ -94,6 +94,7 @@ public class UserController {
   public ResponseEntity getUser() throws Exception {
     Long userId = securityUtil.getCurrentUserId();
     UserDTO.UserInfo myInfo = userService.findMyInfo(userId);
+
     return ResponseEntity.ok(ResponseMessage.builder()
             .status(StatusEnum.OK)
             .data(myInfo)

--- a/src/main/java/com/linkbuddy/global/config/SecurityConfig.java
+++ b/src/main/java/com/linkbuddy/global/config/SecurityConfig.java
@@ -57,8 +57,7 @@ public class SecurityConfig {
                     httpSecuritySessionManagementConfigurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS)); // 세션 미사용 설정
 
     http.authorizeHttpRequests(request -> request
-                    .dispatcherTypeMatchers(DispatcherType.FORWARD).permitAll()
-                    .requestMatchers("/user/join", "/user/signIn", "/favicon.ico", "/user/loginSuccess", "/user/loginFailure").permitAll() // 인증 제외할 url 설정
+                    .requestMatchers("/login", "/user/join", "/user/signIn", "/favicon.ico", "/static/**", "/user/loginSuccess", "/user/loginFailure").permitAll() // 인증 제외할 url 설정
                     .anyRequest().authenticated() // 모든 요청에 대해서 인증 설정
             )
 
@@ -72,11 +71,15 @@ public class SecurityConfig {
                             .failureUrl("/user/loginFailure")
             )
             // Exception Handling 설정
-            .exceptionHandling(exception -> exception
-                    .authenticationEntryPoint(customAuthenticationEntryPoint)) // CustomAuthenticationEntryPoint 등록
+//            .exceptionHandling(exception -> exception
+//                    .authenticationEntryPoint(customAuthenticationEntryPoint)) // CustomAuthenticationEntryPoint 등록
+
 
             //JWT
             .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class); // UsernamePasswordAuthenticationFilter 전에 JWT 인증 필터 거치도록 설정
     return http.build();
+
   }
+
+
 }

--- a/src/main/java/com/linkbuddy/global/config/WebMvcConfig.java
+++ b/src/main/java/com/linkbuddy/global/config/WebMvcConfig.java
@@ -23,6 +23,9 @@ public class WebMvcConfig implements WebMvcConfigurer {
   public void addCorsMappings(CorsRegistry registry) {
     registry.addMapping("/**")
             .allowedOrigins("http://localhost:3000")
-            .allowedMethods("OPTIONS", "GET", "POST", "PUT", "PATCH", "DELETE");
+            .allowedMethods("OPTIONS", "GET", "POST", "PUT", "PATCH", "DELETE")
+            .allowedHeaders("*") // 모든 헤더 허용
+            .allowCredentials(true); // 쿠키를 포함한 요청 허용
+
   }
 }

--- a/src/main/java/com/linkbuddy/global/config/jwt/SecurityUtil.java
+++ b/src/main/java/com/linkbuddy/global/config/jwt/SecurityUtil.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Component;
 
 /**
@@ -31,7 +32,6 @@ public class SecurityUtil {
 
   public Long getCurrentUserId() throws Exception {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
     if (authentication == null || authentication.getName() == null) {
       throw new RuntimeException("인증 정보가 없습니다.");
     }

--- a/src/main/java/com/linkbuddy/global/config/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/linkbuddy/global/config/oauth/OAuth2SuccessHandler.java
@@ -30,15 +30,14 @@ import java.io.IOException;
 @Component
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
   private final JwtTokenProvider tokenProvider;
-  private static final String URI = "/user/loginSuccess";
-
+  private static final String FRONTEND_URI = "http://localhost:3000/user/loginSuccess";
 
   @Override
   public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
     //token 발급
     JwtToken token = tokenProvider.createToken(authentication);
 
-    String redirectUrl = UriComponentsBuilder.fromUriString(URI)
+    String redirectUrl = UriComponentsBuilder.fromUriString(FRONTEND_URI)
             .queryParam("accessToken", token.getAccessToken())
             .queryParam("refreshToken", token.getRefreshToken())
             .build().toUriString();


### PR DESCRIPTION
 ## PR타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링, 코드 포맷팅
- [ ] CI/CD, 환경변수
- [ ] 문서 작업

 ## 내용
### 이슈
- 대부분 메소드마다 존재하는 getCurrntUserId()함수에서 **소셜user정보**를 가져오지 못하는 듯함.
- 백엔드 로직에서 `localhost:8080/login` URL을 자꾸 요청함. 이로 인한 프론트에 CORS에러 발생
![image](https://github.com/user-attachments/assets/2267b28f-44be-4036-9bbf-029f741c6125)

resolves